### PR TITLE
ndims() and broadcast() definitions for generic symbolic types

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -157,4 +157,4 @@ Base.size(x::Symbolic{<:Number}) = ()
 Base.length(x::Symbolic{<:Number}) = 1
 Base.ndims(x::Symbolic{T}) where {T} = Base.ndims(T)
 Base.ndims(::Type{<:Symbolic{T}}) where {T} = Base.ndims(T)
-Base.broadcastable(x::Symbolic) = x
+Base.broadcastable(x::Symbolic) = Ref(x)

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -157,4 +157,4 @@ Base.size(x::Symbolic{<:Number}) = ()
 Base.length(x::Symbolic{<:Number}) = 1
 Base.ndims(x::Symbolic{T}) where {T} = Base.ndims(T)
 Base.ndims(::Type{<:Symbolic{T}}) where {T} = Base.ndims(T)
-Base.broadcastable(x::Symbolic) = Ref(x)
+Base.broadcastable(x::Symbolic{T}) where {T} = Ref(x)

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -155,4 +155,6 @@ Base.literal_pow(::typeof(^), x::Symbolic{<:Number}, ::Val{p}) where {p} = Base.
 # Array-like operations
 Base.size(x::Symbolic{<:Number}) = ()
 Base.length(x::Symbolic{<:Number}) = 1
-Base.ndims(x::Symbolic{<:Number}) = 0
+Base.ndims(x::Symbolic{T}) where {T} = Base.ndims(T)
+Base.ndims(::Type{<:Symbolic{T}}) where {T} = Base.ndims(T)
+Base.broadcastable(x::Symbolic) = x

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,4 +1,4 @@
-using SymbolicUtils: Sym, FnType, Term, Add, Mul, Pow, symtype, operation, arguments
+using SymbolicUtils: Symbolic, Sym, FnType, Term, Add, Mul, Pow, symtype, operation, arguments
 using SymbolicUtils
 using IfElse: ifelse
 using Test
@@ -132,6 +132,15 @@ end
     @eqtest x // Int16(5) == Rational{Int16}(1, 5) * x
     @eqtest 5 // x == 5 / x
     @eqtest x // a == x / a
+end
+
+@testset "array-like operations" begin
+    abstract type SquareDummy end
+    Base.:*(a::Symbolic{SquareDummy}, b) = b^2
+    @syms s t a::SquareDummy A[1:2, 1:2]
+
+    @test isequal(ndims(A), 2)
+    @test isequal(a.*[1 (s+t); t pi], [1 (s+t)^2; t^2 pi^2])
 end
 
 @testset "err test" begin


### PR DESCRIPTION
This PR defines ndims() in terms of the type that a symbolic expression represents. That should be correct also for future/custom types.
Broadcast assumes all types are "scalar" until defined otherwise.

This PR will for example make the following code work in Symbolics.jl:
`using Symbolics`
`@variables s t A[1:2, 1:2]`
`out = (s^2 +s*t -1)*A`